### PR TITLE
Disable outdated crypto, provide DH params for PFS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DEFS = -DNS_ENABLE_SSL $(CFLAGS_EXTRA)
-CFLAGS = -W -Wall -O2 -pthread -lssl $(DEFS)
+CFLAGS = -W -Wall -O2 -pthread -lcrypto -lssl $(DEFS)
 SOURCES = ssl_wrapper.c net_skeleton.c
 
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
To be designated "modern" by Chrome, it needs to be able to negotiate:
  * (EC)DHE key exchange (for PFS)
  * AES or CHACHA cipher
  * AEAD MAC

Everything else is considered "obsolete". Source: [IsSecureTLSCipherSuite](https://chromium.googlesource.com/chromium/src/+/master/net/ssl/ssl_cipher_suite_names.cc#361)

DH key exchange requires parameters (a long prime). These can be generated
with "openssl dhparam 2048" and should ideally be provided by the user,
so we try to get them from the cert+key bundle file first, but fall back
on hard-coded ones if none are supplied.

Fixes #4